### PR TITLE
Fix issue 5704

### DIFF
--- a/packages/bun-vscode/scripts/build.mjs
+++ b/packages/bun-vscode/scripts/build.mjs
@@ -12,7 +12,7 @@ buildSync({
   external: ["vscode"],
   platform: "node",
   format: "cjs",
-  
+
   // The following settings are required to allow for extension debugging
   minify: false,
   sourcemap: true,

--- a/packages/bun-vscode/src/features/debug.ts
+++ b/packages/bun-vscode/src/features/debug.ts
@@ -13,7 +13,6 @@ export const DEBUG_CONFIGURATION: vscode.DebugConfiguration = {
   cwd: "${workspaceFolder}",
   stopOnEntry: false,
   watchMode: false,
-  
 };
 
 export const RUN_CONFIGURATION: vscode.DebugConfiguration = {
@@ -83,7 +82,7 @@ function debugFileCommand(resource?: vscode.Uri) {
 }
 
 function injectDebugTerminal(terminal: vscode.Terminal): void {
-  if (!getConfig("debugTerminal.enabled")) return
+  if (!getConfig("debugTerminal.enabled")) return;
 
   const { name, creationOptions } = terminal;
   if (name !== "JavaScript Debug Terminal") {
@@ -246,4 +245,3 @@ function getRuntime(scope?: vscode.ConfigurationScope): string {
 function getConfig<T>(path: string, scope?: vscode.ConfigurationScope) {
   return vscode.workspace.getConfiguration("bun", scope).get<T>(path);
 }
- 

--- a/packages/bun-vscode/src/features/lockfile.style.ts
+++ b/packages/bun-vscode/src/features/lockfile.style.ts
@@ -1,37 +1,35 @@
 export function styleLockfile(preview: string) {
-    // Match all lines that don't start with a whitespace character
-    const lines = preview.split(/\n(?!\s)/);
+  // Match all lines that don't start with a whitespace character
+  const lines = preview.split(/\n(?!\s)/);
 
-    return lines.map(styleSection).join('\n')
+  return lines.map(styleSection).join("\n");
 }
 
 function styleSection(section: string) {
-    const lines = section.split(/\n/);
+  const lines = section.split(/\n/);
 
-    return lines.map(styleLine).join('\n')
+  return lines.map(styleLine).join("\n");
 }
 
 function styleLine(line: string) {
-    if(line.startsWith('#')){
-        return `<span class="mtk5">${line}</span>`
-    }
+  if (line.startsWith("#")) {
+    return `<span class="mtk5">${line}</span>`;
+  }
 
-    const parts = line.trim().split(' ')
-    if(line.startsWith('    ')){
-        return `<span><span class="mtk1">&nbsp;&nbsp;&nbsp;&nbsp;${parts[0]}&nbsp;</span><span class="mtk16">${parts[1]}</span></span>`
-    }
-    if(line.startsWith('  ')){
-        const leftPart = `<span class="mtk6">&nbsp;&nbsp;${parts[0]}&nbsp;</span>`
+  const parts = line.trim().split(" ");
+  if (line.startsWith("    ")) {
+    return `<span><span class="mtk1">&nbsp;&nbsp;&nbsp;&nbsp;${parts[0]}&nbsp;</span><span class="mtk16">${parts[1]}</span></span>`;
+  }
+  if (line.startsWith("  ")) {
+    const leftPart = `<span class="mtk6">&nbsp;&nbsp;${parts[0]}&nbsp;</span>`;
 
-        if(parts.length === 1)
-            return `<span>${leftPart}</span>`
-        
-        if(parts[1].startsWith('"http://') || parts[1].startsWith('"https://'))
-            return `<span>${leftPart}<span class="mtk12 detected-link">${parts[1]}</span></span>`
-        if(parts[1].startsWith('"'))
-            return `<span>${leftPart}<span class="mtk16">${parts[1]}</span></span>`
-        
-        return `<span>${leftPart}<span class="mtk6">${parts[1]}</span></span>`
-    }
-    return `<span class="mtk1">${line}&nbsp;</span>`
+    if (parts.length === 1) return `<span>${leftPart}</span>`;
+
+    if (parts[1].startsWith('"http://') || parts[1].startsWith('"https://'))
+      return `<span>${leftPart}<span class="mtk12 detected-link">${parts[1]}</span></span>`;
+    if (parts[1].startsWith('"')) return `<span>${leftPart}<span class="mtk16">${parts[1]}</span></span>`;
+
+    return `<span>${leftPart}<span class="mtk6">${parts[1]}</span></span>`;
+  }
+  return `<span class="mtk1">${line}&nbsp;</span>`;
 }

--- a/packages/bun-vscode/src/features/tasks/package.json.ts
+++ b/packages/bun-vscode/src/features/tasks/package.json.ts
@@ -189,7 +189,7 @@ function registerHoverProvider(context: vscode.ExtensionContext) {
         return;
       }
 
-      const terminal = vscode.window.createTerminal({name});
+      const terminal = vscode.window.createTerminal({ name });
       terminal.show();
       terminal.sendText(`bun ${script}`);
     }),

--- a/src/which.zig
+++ b/src/which.zig
@@ -19,7 +19,7 @@ fn checkPath(filepath: [:0]const u8) bool {
 // Like /usr/bin/which but without needing to exec a child process
 // Remember to resolve the symlink if necessary
 pub fn which(buf: *[bun.MAX_PATH_BYTES]u8, path: []const u8, cwd: []const u8, bin: []const u8) ?[:0]const u8 {
-    if (bin.len == 0) return null;
+    // if (bin.len == 0) return null;
 
     // handle absolute paths
     if (std.fs.path.isAbsolute(bin)) {

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -2636,9 +2636,9 @@ describe("expect()", () => {
 
       expect({ a: [1, 2, 3] }).toMatchObject({ a: expect.arrayContaining([1, 2]) });
       expect({ a: [1, 2, 3] }).not.toMatchObject({ a: expect.arrayContaining([4]) });
-      expect({ a: ['hello', 'world'] }).toMatchObject({ a: expect.arrayContaining([]) });
-      expect({ a: ['hello', 'world'] }).toMatchObject({ a: expect.arrayContaining(['world']) });
-      expect({ a: ['hello', 'world'] }).not.toMatchObject({ a: expect.arrayContaining(['hello', 'mars']) });
+      expect({ a: ["hello", "world"] }).toMatchObject({ a: expect.arrayContaining([]) });
+      expect({ a: ["hello", "world"] }).toMatchObject({ a: expect.arrayContaining(["world"]) });
+      expect({ a: ["hello", "world"] }).not.toMatchObject({ a: expect.arrayContaining(["hello", "mars"]) });
 
       expect([]).toMatchObject([]);
       expect([]).toMatchObject({});

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -67,7 +67,7 @@ describe("fs.watch", () => {
     const root = path.join(testDir, "add-directory");
     try {
       fs.mkdirSync(root);
-    } catch { }
+    } catch {}
     let err: Error | undefined = undefined;
     const watcher = fs.watch(root, { signal: AbortSignal.timeout(3000) });
     watcher.on("change", (event, filename) => {
@@ -102,7 +102,7 @@ describe("fs.watch", () => {
     const root = path.join(testDir, "add-subdirectory");
     try {
       fs.mkdirSync(root);
-    } catch { }
+    } catch {}
     const subfolder = path.join(root, "subfolder");
     fs.mkdirSync(subfolder);
     const watcher = fs.watch(root, { recursive: true, signal: AbortSignal.timeout(3000) });
@@ -438,7 +438,7 @@ describe("fs.promises.watch", () => {
     const root = path.join(testDir, "add-promise-directory");
     try {
       fs.mkdirSync(root);
-    } catch { }
+    } catch {}
     let success = false;
     let err: Error | undefined = undefined;
     try {
@@ -480,7 +480,7 @@ describe("fs.promises.watch", () => {
     const root = path.join(testDir, "add-promise-subdirectory");
     try {
       fs.mkdirSync(root);
-    } catch { }
+    } catch {}
     const subfolder = path.join(root, "subfolder");
     fs.mkdirSync(subfolder);
     let success = false;

--- a/test/regression/issue/5704.test.ts
+++ b/test/regression/issue/5704.test.ts
@@ -7,7 +7,7 @@ import { bunEnv, bunExe } from "harness";
 
 test("running a empty script should not return a missing script error", () => {
   const tmp = mkdtempSync(join(tmpdir(), "bun-test-"));
-  writeFileSync(join(tmp, "empty-file.ts"), '');
+  writeFileSync(join(tmp, "empty-file.ts"), "");
 
   const result = Bun.spawnSync({
     cmd: [bunExe(), "run", join(tmp, "empty-file.ts")],

--- a/test/regression/issue/5704.test.ts
+++ b/test/regression/issue/5704.test.ts
@@ -1,0 +1,19 @@
+// https://github.com/oven-sh/bun/issues/5704
+import { test, expect } from "bun:test";
+import { tmpdir } from "os";
+import { mkdtempSync, writeFileSync } from "fs";
+import { join } from "path";
+import { bunEnv, bunExe } from "harness";
+
+test("running a empty script should not return a missing script error", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "bun-test-"));
+  writeFileSync(join(tmp, "empty-file.ts"), '');
+
+  const result = Bun.spawnSync({
+    cmd: [bunExe(), "run", join(tmp, "empty-file.ts")],
+    cwd: tmp,
+    env: bunEnv,
+  });
+
+  expect(result.exitCode).toBe(0);
+});


### PR DESCRIPTION
### What does this PR do?

<!-- **Please explain what your changes do**, example: -->

<!--

This adds a new flag --bail to bun test. When set, it will stop running tests after the first failure. This is useful for CI environments where you want to fail fast.

-->

- [ ] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [x] Code changes

### How did you verify your code works?

<!-- **For code changes, please include automated tests**. Feel free to uncomment the line below -->

- [x] I included a test for the new code, or an existing test covers it

<!-- If JavaScript/TypeScript modules or builtins changed:

- [ ] I ran `make js` and committed the transpiled changes
- [ ] I or my editor ran Prettier on the changed files (or I ran `bun fmt`)
- [ ] I included a test for the new code, or an existing test covers it

-->

<!-- If Zig files changed:

- [ ] I checked the lifetime of memory allocated to verify it's (1) freed and (2) only freed when it should be
- [ ] I or my editor ran `zig fmt` on the changed files
- [ ] I included a test for the new code, or an existing test covers it
- [ ] JSValue used outside outside of the stack is either wrapped in a JSC.Strong or is JSValueProtect'ed
-->

<!-- If new methods, getters, or setters were added to a publicly exposed class:

- [ ] I added TypeScript types for the new methods, getters, or setters
-->

<!-- If dependencies in tests changed:

- [ ] I made sure that specific versions of dependencies are used instead of ranged or tagged versions
-->

<!-- If functions were added to exports.zig or bindings.zig

- [ ] I ran `make headers` to regenerate the C header file

-->

<!-- If \*.classes.ts files were added or changed:

- [ ] I ran `make codegen` to regenerate the C++ and Zig code
-->

<!-- If a new builtin ESM/CJS module was added:

- [ ] I updated Aliases in `module_loader.zig` to include the new module
- [ ] I added a test that imports the module
- [ ] I added a test that require() the module
-->
